### PR TITLE
Fix deleting projects

### DIFF
--- a/src/components/projects/ProjectCard.jsx
+++ b/src/components/projects/ProjectCard.jsx
@@ -55,7 +55,6 @@ const ProjectCard = ({ id, name, description }) => {
                 });
                 throw new Error("error");
             } else {
-                onClose();
                 navigate(0);
             }
         }).catch(err => {


### PR DESCRIPTION
Indeed, the problem was random `onClose()` in `deleteProject` function. 

Deleting projects with trash can icon in projects tab should work correctly. 